### PR TITLE
Feat/expand encode macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,16 +145,20 @@ LogMod provides macros for ANSI color formatting of arbitrary text:
 ```c
 // Dynamic color formatting (applies color only if logger enables it)
 logmod_logger_set_color(logger, 1); // Enable color for this logger
-printf("%s World!\n", LME(logger, "Hello", RED, BOLD, FOREGROUND));
+printf("%s World!\n", LML(logger, "Hello", RED, BOLD, FOREGROUND));
 // Static color formatting (always applies color)
-printf(LMES("Hello", GREEN, UNDERLINE, FOREGROUND) " World!\n");
+printf(LMS("Hello", GREEN, UNDERLINE, FOREGROUND) " World!\n");
 ```
 Should print to console, respectively:
 
 ![terminal output](docs/terminal.png)
 
 
-The `LME` macro (shorthand for `LOGMOD_ENCODE`) automatically applies the logger's color settings, while `LMES` (shortdhand for `LOGMOD_ENCODE_STATIC`) applies the specified color regardless of the logger's settings.
+The `LML` macro (shorthand for `LOGMOD_ENCODE_LOGGER`) automatically applies the logger's color settings, while `LMS` (shorthand for `LOGMOD_ENCODE_STATIC`) applies the specified color regardless of the logger's settings.
+
+LogMod also provides additional encoding macros:
+- `LME` - Shorthand for `LOGMOD_ENCODE` (basic encoding)
+- `LMT` - Shorthand for `LOGMOD_ENCODE_TOGGLE` (conditional encoding based on a boolean toggle)
 
 Available colors, styles, and visibility options:
 

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ logmod_logger_set_options(logger, options);
 logmod_logger_set_quiet(logger, 0);     // Enable console output
 logmod_logger_set_color(logger, 1);     // Enable colored output
 logmod_logger_set_logfile(logger, fp);  // Set log file
+logmod_logger_set_id_visibility(logger, 1, 1);  // Show both application ID and context ID
 ```
 
 ### Cleanup
@@ -390,6 +391,35 @@ logmod_err logmod_logger_set_options(struct logmod_logger *logger, struct logmod
 Sets the options for the logger.
 - `logger`: Pointer to the logger structure.
 - `options`: Logger options structure.
+
+### `logmod_logger_set_id_visibility`
+
+```c
+logmod_err logmod_logger_set_id_visibility(struct logmod_logger *logger, int show_app_id, int show_context_id);
+```
+
+Controls the visibility of application ID and context ID in log messages.
+- `logger`: Pointer to the logger structure.
+- `show_app_id`: Set to 1 to show the application ID in log messages, 0 to hide it.
+- `show_context_id`: Set to 1 to show the context ID in log messages, 0 to hide it.
+Returns `LOGMOD_OK` on success, error code on failure.
+
+```c
+// Examples:
+// Show both application ID and context ID
+logmod_logger_set_id_visibility(logger, 1, 1);
+
+// Hide application ID, show context ID (default behavior)
+logmod_logger_set_id_visibility(logger, 0, 1);
+
+// Show application ID, hide context ID
+logmod_logger_set_id_visibility(logger, 1, 0);
+
+// Hide both application ID and context ID
+logmod_logger_set_id_visibility(logger, 0, 0);
+```
+
+This setting affects how messages are formatted when displayed in the console or written to a log file. Showing the application ID is useful in multi-application environments, while showing the context ID helps identify the source module within your application.
 
 ### `logmod_logger_set_quiet`
 

--- a/test/test.c
+++ b/test/test.c
@@ -399,7 +399,7 @@ should_encode_ansi_string(void)
     logger = logmod_get_logger(&logmod, "MODULE_A");
     logmod_logger_set_color(logger, 1);
 
-    result = LME(logger, TEST_STRING, RED, BOLD, FOREGROUND);
+    result = LML(logger, TEST_STRING, RED, BOLD, FOREGROUND);
     ASSERT_STR_EQm(result, "\x1b[1;31mtest string\x1b[0m", result);
 
     PASS();
@@ -417,7 +417,7 @@ should_return_original_string_when_color_disabled(void)
     logger = logmod_get_logger(&logmod, "MODULE_A");
     logmod_logger_set_color(logger, 0);
 
-    result = LME(logger, TEST_STRING, RED, BOLD, FOREGROUND);
+    result = LML(logger, TEST_STRING, RED, BOLD, FOREGROUND);
     ASSERT_MEM_EQm(result, TEST_STRING, result, sizeof(TEST_STRING) - 1);
 
     PASS();
@@ -435,13 +435,13 @@ should_handle_different_ansi_visibilities(void)
     logger = logmod_get_logger(&logmod, "MODULE_A");
     logmod_logger_set_color(logger, 1);
 
-    result = LME(logger, TEST_STRING, GREEN, REGULAR, FOREGROUND);
+    result = LML(logger, TEST_STRING, GREEN, REGULAR, FOREGROUND);
     ASSERT_NEQ(NULL, strstr(result, "\x1b[0;32m"));
 
-    result = LME(logger, TEST_STRING, BLUE, REGULAR, BACKGROUND);
+    result = LML(logger, TEST_STRING, BLUE, REGULAR, BACKGROUND);
     ASSERT_NEQ(NULL, strstr(result, "\x1b[0;44m"));
 
-    result = LME(logger, TEST_STRING, RED, REGULAR, INTENSITY);
+    result = LML(logger, TEST_STRING, RED, REGULAR, INTENSITY);
     ASSERT_NEQ(NULL, strstr(result, "\x1b[0;91m"));
 
     PASS();
@@ -459,15 +459,15 @@ should_handle_different_ansi_styles(void)
     logger = logmod_get_logger(&logmod, "MODULE_A");
     logmod_logger_set_color(logger, 1);
 
-    result = LME(logger, TEST_STRING, CYAN, REGULAR, FOREGROUND);
+    result = LML(logger, TEST_STRING, CYAN, REGULAR, FOREGROUND);
     ASSERT_NEQ(NULL, result);
     ASSERT_NEQ(NULL, strstr(result, "\x1b[0;36m"));
 
-    result = LME(logger, TEST_STRING, CYAN, BOLD, FOREGROUND);
+    result = LML(logger, TEST_STRING, CYAN, BOLD, FOREGROUND);
     ASSERT_NEQ(NULL, result);
     ASSERT_NEQ(NULL, strstr(result, "\x1b[1;36m"));
 
-    result = LME(logger, TEST_STRING, CYAN, UNDERLINE, FOREGROUND);
+    result = LML(logger, TEST_STRING, CYAN, UNDERLINE, FOREGROUND);
     ASSERT_NEQ(NULL, result);
     ASSERT_NEQ(NULL, strstr(result, "\x1b[4;36m"));
 


### PR DESCRIPTION
- Add logmod_logger_set_id_visibility() for enabling/disabling id visibility
- Add different flavors of color-encode macros